### PR TITLE
Fix header memory leak on scroll

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -28,16 +28,22 @@ class Header extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    const { isScrolled } = this.state;
-    window.addEventListener('scroll', () => {
-      if (window.pageYOffset > 0) {
-        if (isScrolled) return;
-        this.setState({ isScrolled: true });
-      } else {
-        this.setState({ isScrolled: false });
-      }
-    });
+    window.addEventListener('scroll', this.handleScroll);
   }
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.handleScroll);
+  }
+
+  handleScroll = () => {
+    const { isScrolled } = this.state;
+    if (window.pageYOffset > 0) {
+      if (isScrolled) return;
+      this.setState({ isScrolled: true });
+    } else {
+      this.setState({ isScrolled: false });
+    }
+  };
 
   isProjectActive = (project: Project) => {
     const { location } = this.props;


### PR DESCRIPTION
## Description

This PR is a bug fix.

Scrolling / changing routes (because of Header component state) would expose a memory leak. This PR fixes that by checking that by removing the `scroll` event listener on `componentWillUnmount`.

Closes #5 