### PR TITLE
Dev Portal - Fix broken doc links

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,15 +3,14 @@
  * Pages
  */
 export const PAGE_INDEX = '/';
-export const PAGE_GET_STARTED_COLONYJS = '/docs/colonyjs/intro-get-started';
+export const PAGE_GET_STARTED_COLONYJS = '/colonyjs/intro-get-started';
 export const PAGE_DEVELOPER_PORTAL = PAGE_INDEX;
 export const PAGE_GET_INVOLVED = '/get-involved';
 export const PAGE_LOGIN = '/login';
 export const PAGE_MEDIA_KIT = '/media-kit';
 export const PAGE_PRIVACY_POLICY = 'https://colony.io/terms/#privacy-policy';
 export const PAGE_TERMS_SERVICE = 'https://colony.io/terms/';
-export const PAGE_BUG_BOUNTY =
-  '/docs/colonynetwork/bug-bounty-program-overview';
+export const PAGE_BUG_BOUNTY = '/colonynetwork/bug-bounty-program-overview';
 
 /*
  * Absolute


### PR DESCRIPTION
## Description

Bug fix. Fix some links that were broken after changing the docs path prefix.

**Changes** 🏗

* Removed `/docs` prefix from some route paths.