### PR TITLE
Dev Portal - Ignore documentation templates

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,7 @@ const sourcePlugins = {
     //   options: {
     //     name: 'budgetBox',
     //     path: path.resolve(__dirname, '..', 'budgetBox', 'docs'),
+    //     ignore: [ '**/templates/*' ],
     //   },
     // },
     {
@@ -28,6 +29,7 @@ const sourcePlugins = {
       options: {
         name: 'colonyJS',
         path: path.resolve(__dirname, '..', 'colonyJS', 'docs'),
+        ignore: [ '**/templates/*' ],
       },
     },
     {
@@ -35,6 +37,7 @@ const sourcePlugins = {
       options: {
         name: 'colonyNetwork',
         path: path.resolve(__dirname, '..', 'colonyNetwork', 'docs'),
+        ignore: [ '**/templates/*' ],
       },
     },
     {
@@ -42,6 +45,7 @@ const sourcePlugins = {
       options: {
         name: 'colonyStarter',
         path: path.resolve(__dirname, '..', 'colonyStarter', 'docs'),
+        ignore: [ '**/templates/*' ],
       },
     },
     // {
@@ -49,6 +53,7 @@ const sourcePlugins = {
     //   options: {
     //     name: 'pinion',
     //     path: path.resolve(__dirname, '..', 'pinion', 'docs'),
+    //     ignore: [ '**/templates/*' ],
     //   },
     // },
     {
@@ -56,6 +61,7 @@ const sourcePlugins = {
       options: {
         name: 'purser',
         path: path.resolve(__dirname, '..', 'purser', 'docs'),
+        ignore: [ '**/templates/*' ],
       },
     },
     // {
@@ -63,6 +69,7 @@ const sourcePlugins = {
     //   options: {
     //     name: 'solcover',
     //     path: path.resolve(__dirname, '..', 'solcover', 'docs'),
+    //     ignore: [ '**/templates/*' ],
     //   },
     // },
     {
@@ -70,6 +77,7 @@ const sourcePlugins = {
       options: {
         name: 'tailor',
         path: path.resolve(__dirname, '..', 'tailor', 'docs'),
+        ignore: [ '**/templates/*' ],
       },
     },
     // {
@@ -77,6 +85,7 @@ const sourcePlugins = {
     //   options: {
     //     name: 'trufflepig',
     //     path: path.resolve(__dirname, '..', 'trufflepig', 'docs'),
+    //     ignore: [ '**/templates/*' ],
     //   },
     // },
   ],


### PR DESCRIPTION
## Description

This pull request ignores any documentation within a `templates` directory when sourcing markdown files in `development`. The `gatsby-source-github-docs` plugin does not source any markdown files in subdirectories, so no need to add any additional configuration for `production`.

I added the ignore option to all repositories for convention sake. colonyNetwork will be needing this in the near future, the folder structure in colonyJS could be improved to use this, and our other projects may need it in the future as well.

**Changes** 🏗

* Updated gatsby configuration