### PR TITLE
Use colonyNetwork master branch

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -103,7 +103,7 @@ const sourcePlugins = {
         {
           owner: 'JoinColony',
           repo: 'colonyNetwork',
-          expression: 'develop:docs/',
+          expression: 'master:docs/',
           name: 'colonyNetwork',
         },
         {


### PR DESCRIPTION
## Description

This pull request switches the colonyNetwork docs configuration to use the `master` branch.

**Changes** 🏗

* Change `develop` to `master` for colonyNetwork docs configuration