### PR TITLE
Website - Add navigation which animates in on scroll

### DIFF
--- a/src/modules/layouts/components/WebsiteLayout/Header/Header.jsx
+++ b/src/modules/layouts/components/WebsiteLayout/Header/Header.jsx
@@ -45,11 +45,13 @@ const Header = ({ appearance: appearanceProp, showOnScrollHeight }: Props) => {
   const [showScrolledNav, setShowScrolledNav] = useState(false);
   const { headerHeight } = useContext(ThemeContext);
 
+  const isShowOnScrollEnabled = typeof showOnScrollHeight !== 'undefined';
+
   const handleScroll = useCallback(() => {
     if (typeof window !== 'undefined') {
       const scrollTop = window.scrollTop || window.pageYOffset;
       const shouldShow =
-        showOnScrollHeight &&
+        isShowOnScrollEnabled &&
         scrollTop > headerHeight && // make sure we've scrolled past the regular top nav. Useful for responsiveness.
         scrollTop > showOnScrollHeight;
       if (shouldShow && !showScrolledNav) {
@@ -59,18 +61,23 @@ const Header = ({ appearance: appearanceProp, showOnScrollHeight }: Props) => {
         setShowScrolledNav(false);
       }
     }
-  }, [headerHeight, showOnScrollHeight, showScrolledNav]);
+  }, [
+    headerHeight,
+    isShowOnScrollEnabled,
+    showOnScrollHeight,
+    showScrolledNav,
+  ]);
 
   useLayoutEffect(() => {
     // Incase page is loaded at a scrolled position
-    if (showOnScrollHeight) {
+    if (isShowOnScrollEnabled) {
       handleScroll();
     }
-  }, [handleScroll, showOnScrollHeight]);
+  }, [handleScroll, isShowOnScrollEnabled, showOnScrollHeight]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      if (showOnScrollHeight) {
+      if (isShowOnScrollEnabled) {
         window.addEventListener('scroll', handleScroll);
       }
     }
@@ -79,7 +86,7 @@ const Header = ({ appearance: appearanceProp, showOnScrollHeight }: Props) => {
         window.removeEventListener('scroll', handleScroll);
       }
     };
-  }, [handleScroll, showOnScrollHeight]);
+  }, [handleScroll, isShowOnScrollEnabled, showOnScrollHeight]);
 
   const appearance = showScrolledNav
     ? ({ logoTheme: 'dark', theme: 'scrolled' }: Appearance)

--- a/src/modules/layouts/components/WebsiteLayout/Header/Header.module.css
+++ b/src/modules/layouts/components/WebsiteLayout/Header/Header.module.css
@@ -55,12 +55,6 @@
   border-bottom-color: var(--navy);
 }
 
-.themeTransparent {
-  position: absolute;
-  width: 100%;
-  z-index: 100;
-}
-
 .themeTransparent .navLink {
   color: var(--colony-white);
 }

--- a/src/modules/layouts/components/WebsiteLayout/Header/types.js
+++ b/src/modules/layouts/components/WebsiteLayout/Header/types.js
@@ -8,5 +8,9 @@ export type Appearance = {|
 
 export type Props = {|
   appearance?: Appearance,
+  /**
+   * If value is smaller than header height, header height will be used
+   * instead. This prevents 2 navs from being visible at any one time.
+   */
   showOnScrollHeight?: number,
 |};

--- a/src/modules/layouts/components/WebsiteLayout/WebsiteLayout.jsx
+++ b/src/modules/layouts/components/WebsiteLayout/WebsiteLayout.jsx
@@ -11,6 +11,8 @@ import Footer from './Footer';
 import Header from './Header';
 import { useElementHeight } from '~hooks';
 
+import styles from './WebsiteLayout.module.css';
+
 type Props = {|
   children: Element<typeof Component>,
   headerAppearance?: HeaderAppearance,
@@ -23,8 +25,15 @@ const WebsiteLayout = ({ children, headerAppearance }: Props) => {
   const height = useElementHeight(ref);
   return (
     <ThemeContext.Provider value={{ headerHeight: height }}>
-      <div ref={ref}>
-        <Header appearance={headerAppearance} showOnScrollHeight={300} />
+      <div
+        className={
+          headerAppearance && headerAppearance.theme === 'transparent'
+            ? styles.transparentNav
+            : null
+        }
+        ref={ref}
+      >
+        <Header appearance={headerAppearance} showOnScrollHeight={0} />
       </div>
       {children}
       <Footer />

--- a/src/modules/layouts/components/WebsiteLayout/WebsiteLayout.module.css
+++ b/src/modules/layouts/components/WebsiteLayout/WebsiteLayout.module.css
@@ -1,0 +1,6 @@
+
+.transparentNav {
+  position: absolute;
+  width: 100%;
+  z-index: 100;
+}


### PR DESCRIPTION
## Description

This PR adds a feature which displays the navigation on scroll.

**New stuff** ✨

* `scrolled` Header theme

**Changes** 🏗

* Add `showOnScrollHeight` prop to the Header
* Show the nav if scrolled past the `showOnScrollHeight` ☝️ and at least past the height of the static top nav

**Deletions** ⚰️

* Website layout css file

**Demo** 🎥 

![Scrolled Nav](https://user-images.githubusercontent.com/3052635/61738936-00452b00-ad51-11e9-97c7-912d47f51507.gif)

Resolves #72 