### PR TITLE
Fix condition for displaying MetaMask screen

### DIFF
--- a/src/modules/layouts/components/DeveloperPortalLayout/DeveloperPortalLayout.jsx
+++ b/src/modules/layouts/components/DeveloperPortalLayout/DeveloperPortalLayout.jsx
@@ -96,7 +96,7 @@ const DeveloperPortalLayout = ({ children, intl: { locale } }: Props) => {
         user={user}
         wallet={wallet}
       />
-      {!wallet && !loadingWallet && walletRequired ? (
+      {!wallet && walletRequired ? (
         <MetaMask />
       ) : (
         <div>


### PR DESCRIPTION
## Description

This PR updates the condition for when the MetaMask screen is displayed.

**Changes** 🏗

* Remove `!loadingWallet` from condition for displaying MetaMask screen

Closes #99 
