### PR TITLE
Add `Blog` link to footer resources menu

### DIFF
--- a/src/modules/layouts/components/WebsiteLayout/Footer/Menus/Menus.jsx
+++ b/src/modules/layouts/components/WebsiteLayout/Footer/Menus/Menus.jsx
@@ -6,6 +6,7 @@ import { withPrefix } from 'gatsby';
 
 import VerticalMenu from '~core/VerticalMenu';
 import {
+  COLONY_BLOG,
   COLONY_DISCOURSE_SUPPORT,
   COLONY_GITHUB_BUDGETBOX,
   PAGE_ABOUT_COLONY_NETWORK,
@@ -36,6 +37,10 @@ const MSG = defineMessages({
   headingResources: {
     id: 'layouts.WebsiteLayout.Footer.Menus.headingResources',
     defaultMessage: 'Resources',
+  },
+  linkBlog: {
+    id: 'layouts.WebsiteLayout.Footer.Menus.linkBlog',
+    defaultMessage: 'Blog',
   },
   linkDapp: {
     id: 'layouts.WebsiteLayout.Footer.Menus.linkDapp',
@@ -161,6 +166,11 @@ const Menus = () => {
           headingAppearance={{ theme: 'dark' }}
           headingText={MSG.headingResources}
           menuItems={[
+            {
+              className: styles.footerMenuLink,
+              href: COLONY_BLOG,
+              text: MSG.linkBlog,
+            },
             {
               className: styles.footerMenuLink,
               href: COLONY_GITHUB_BUDGETBOX,


### PR DESCRIPTION
## Description

This PR adds a link to the blog to the `Resources` menu in the footer of the `WebsiteLayout`.

**New stuff** ✨

* `linkBlog` i18n message
* Add link to resources menu

**Screenshot** 📷 

![Screen Shot 2019-09-10 at 1 14 29 PM](https://user-images.githubusercontent.com/3052635/64639199-f80e8100-d3cc-11e9-8b1f-25490478dc6f.png)
