### PR TITLE
Change header link to point to the Betacolony

### DIFF
--- a/src/modules/layouts/components/WebsiteLayout/Header/Header.jsx
+++ b/src/modules/layouts/components/WebsiteLayout/Header/Header.jsx
@@ -16,7 +16,7 @@ import Link from '~core/Link';
 import NavigationToggle from '~core/NavigationToggle';
 import { getMainClasses } from '~utils/css';
 import {
-  COLONY_APP,
+  COLONY_APP_BETA_COLONY,
   COLONY_DISCORD,
   COLONY_DISCOURSE,
   DOCS_COLONY_JS_GET_STARTED,
@@ -56,9 +56,9 @@ const MSG = defineMessages({
     id: 'layouts.WebsiteLayout.Header.navLinkAbout',
     defaultMessage: 'About',
   },
-  navLinkApp: {
-    id: 'layouts.WebsiteLayout.Header.navLinkApp',
-    defaultMessage: 'Go to app',
+  navLinkBetaColony: {
+    id: 'layouts.WebsiteLayout.Header.navLinkBetaColony',
+    defaultMessage: 'Go to the Betacolony',
   },
   navLinkCommunity: {
     id: 'layouts.WebsiteLayout.Header.navLinkCommunity',
@@ -308,8 +308,8 @@ const Header = ({
               />
               <Link
                 className={styles.navLinkAlt}
-                href={COLONY_APP}
-                text={MSG.navLinkApp}
+                href={COLONY_APP_BETA_COLONY}
+                text={MSG.navLinkBetaColony}
               />
               <div className={styles.mobileButtons}>
                 <Button
@@ -319,8 +319,8 @@ const Header = ({
                     theme: 'primaryHollow',
                   }}
                   className={styles.mobileButton}
-                  linkTo={COLONY_APP}
-                  text={MSG.navLinkApp}
+                  linkTo={COLONY_APP_BETA_COLONY}
+                  text={MSG.navLinkBetaColony}
                 />
                 <Button
                   appearance={{


### PR DESCRIPTION
This PR is a small change that will be pushed into production alongside the new [`v2.5.0`](https://github.com/JoinColony/colonyDapp/releases/tag/untagged-604888a8d016c3caef40) app release that enables browsing the app w/o first connection a wallet.

In order to take advantage of that, we won't direct users from the website to the `/connect` route anymore, but instead, prompt them to go browse the [`Betacolony`](https://colony.io/colony/betacolony).

**Changes**

- [x] `Header` now points to directly to the beta colony

**Screenshots**

![Screenshot from 2020-06-22 17-25-00](https://user-images.githubusercontent.com/1193222/85300451-3930d700-b4af-11ea-92c9-b1de4b2ad0d7.png)
![Screenshot from 2020-06-22 17-25-13](https://user-images.githubusercontent.com/1193222/85300460-3a620400-b4af-11ea-8d76-befa92c48276.png)

