### PR TITLE
Disable or Remove Links to App

### DIFF
--- a/src/modules/layouts/components/WebsiteLayout/Header/Header.jsx
+++ b/src/modules/layouts/components/WebsiteLayout/Header/Header.jsx
@@ -16,7 +16,6 @@ import Link from '~core/Link';
 import NavigationToggle from '~core/NavigationToggle';
 import { getMainClasses } from '~utils/css';
 import {
-  COLONY_APP_BETA_COLONY,
   COLONY_DISCORD,
   COLONY_DISCOURSE,
   DOCS_COLONYJS,
@@ -275,22 +274,7 @@ const Header = ({
                 href={COLONY_DISCORD}
                 text={MSG.navLinkCommunity}
               />
-              <Link
-                className={styles.navLinkAlt}
-                href={COLONY_APP_BETA_COLONY}
-                text={MSG.navLinkBetaColony}
-              />
               <div className={styles.mobileButtons}>
-                <Button
-                  appearance={{
-                    borderRadius: 'none',
-                    font: 'tiny',
-                    theme: 'primaryHollow',
-                  }}
-                  className={styles.mobileButton}
-                  linkTo={COLONY_APP_BETA_COLONY}
-                  text={MSG.navLinkBetaColony}
-                />
                 <Button
                   appearance={{
                     borderRadius: 'none',

--- a/src/modules/pages/components/Website/AboutMetaColony/Hero/Hero.jsx
+++ b/src/modules/pages/components/Website/AboutMetaColony/Hero/Hero.jsx
@@ -4,12 +4,10 @@ import React, { useContext } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Announcement from '~core/Announcement';
-import Button from '~core/Button';
 import Heading from '~core/Heading';
 import Paragraph from '~core/Paragraph';
 import ThemeContext from '~layouts/WebsiteLayout/context';
 import SEO from '~parts/SEO';
-import { COLONY_APP_BETA_COLONY } from '~routes';
 
 import styles from './Hero.module.css';
 
@@ -98,15 +96,6 @@ const Hero = () => {
           >
             <FormattedMessage {...MSG.subTitle} values={{ br: <br /> }} />
           </Heading>
-          <Button
-            appearance={{
-              borderRadius: 'none',
-              padding: 'huge',
-              theme: 'primary',
-            }}
-            linkTo={COLONY_APP_BETA_COLONY}
-            text={MSG.buttonText}
-          />
         </div>
         <div className={styles.subBodyContainer}>
           <Paragraph appearance={{ margin: 'none' }} text={MSG.subBody} />

--- a/src/modules/pages/components/Website/AboutMetaColony/Team/Team.jsx
+++ b/src/modules/pages/components/Website/AboutMetaColony/Team/Team.jsx
@@ -4,11 +4,9 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { withPrefix } from 'gatsby';
 
-import Button from '~core/Button';
 import Heading from '~core/Heading';
 import Image from '~core/Image';
 import Paragraph from '~core/Paragraph';
-import { COLONY_APP_BETA_COLONY } from '~routes';
 
 import styles from './Team.module.css';
 
@@ -75,17 +73,6 @@ const Team = () => (
             }}
             text={MSG.subTitle}
           />
-          <div className={styles.buttonContainer}>
-            <Button
-              appearance={{
-                borderRadius: 'none',
-                padding: 'huge',
-                theme: 'primary',
-              }}
-              linkTo={COLONY_APP_BETA_COLONY}
-              text={MSG.button}
-            />
-          </div>
         </div>
       </div>
     </div>

--- a/src/modules/pages/components/Website/HomePage/Hero/Hero.jsx
+++ b/src/modules/pages/components/Website/HomePage/Hero/Hero.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { useCallback, useContext } from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { navigate } from '@reach/router';
 
 import Announcement from '~core/Announcement';
@@ -10,9 +10,10 @@ import Heading from '~core/Heading';
 import Image from '~core/Image';
 import InputGroup from '~core/InputGroup';
 import Paragraph from '~core/Paragraph';
+import Popover from '~core/Popover';
 import ThemeContext from '~layouts/WebsiteLayout/context';
 import SEO from '~parts/SEO';
-import { COLONY_APP, PAGE_CONTACT } from '~routes';
+import { PAGE_CONTACT } from '~routes';
 
 import styles from './Hero.module.css';
 
@@ -40,6 +41,11 @@ const MSG = defineMessages({
   buttonGetStarted: {
     id: 'pages.Website.HomePage.Hero.buttonGetStarted',
     defaultMessage: 'Get Started',
+  },
+  tooltipColonyCreationDisabled: {
+    id: 'users.CreateColonyWizard.StepColonyName.tooltipColonyCreationDisabled',
+    // eslint-disable-next-line max-len
+    defaultMessage: `Due to the extraordinarily high Ethereum gas prices, we’ve decided to disable colony creation to prevent new users from incurring unexpectedly high costs. A new and improved Colony V2 will be available on xDai soon!`,
   },
 });
 
@@ -83,16 +89,44 @@ const Hero = () => {
               appearance={{ size: 'medium', theme: 'invert' }}
               text={MSG.description}
             />
-            <Button
-              appearance={{
-                borderRadius: 'none',
-                size: 'large',
-                theme: 'primary',
-              }}
-              className={styles.button}
-              linkTo={COLONY_APP}
-              text={MSG.buttonGetStarted}
-            />
+            <span className={styles.docsDropdownParent}>
+              <Popover
+                appearance={{ theme: 'grey' }}
+                content={() => (
+                  <div className={styles.colonyCreationDisabled}>
+                    <FormattedMessage {...MSG.tooltipColonyCreationDisabled} />
+                  </div>
+                )}
+                /*
+                 * `isOpen` is always true for a11y purposes. This ensures the dropdown
+                 * menu is always in the DOM, and visibility is controlled via CSS.
+                 */
+                isOpen
+                placement="top"
+                popperProps={{
+                  modifiers: {
+                    offset: {
+                      offset: '0, 15px',
+                    },
+                  },
+                }}
+                trigger="disabled"
+                wrapperClassName={styles.docsDropdownContainer}
+              >
+                <span>
+                  <Button
+                    appearance={{
+                      borderRadius: 'none',
+                      size: 'large',
+                      theme: 'primary',
+                    }}
+                    className={styles.button}
+                    text={MSG.buttonGetStarted}
+                    disabled
+                  />
+                </span>
+              </Popover>
+            </span>
           </div>
         </div>
         <InputGroup

--- a/src/modules/pages/components/Website/HomePage/Hero/Hero.module.css
+++ b/src/modules/pages/components/Website/HomePage/Hero/Hero.module.css
@@ -39,6 +39,23 @@
   color: #ffffff;
 }
 
+.main .button:disabled:hover,
+.main .button:disabled:active {
+  background-color: #788CA0;
+  border-color: #ffffff;
+  color: #ffffff;
+}
+
+.docsDropdownParent .docsDropdownContainer {
+  display: none;
+  visibility: hidden;
+}
+
+.colonyCreationDisabled {
+  width: 420px;
+  padding: 15px;
+}
+
 @media (mediumUp) {
   .imageContainer {
     display: flex;
@@ -46,6 +63,15 @@
 
   .textContainer {
     padding: 20px 280px 20px 120px;
+  }
+
+   .docsDropdownParent .docsDropdownContainer {
+    display: block;
+  }
+
+  .docsDropdownParent:hover .docsDropdownContainer,
+  .docsDropdownParent:focus-within .docsDropdownContainer {
+    visibility: visible;
   }
 }
 

--- a/src/modules/pages/components/Website/ProductApp/Hero/Hero.jsx
+++ b/src/modules/pages/components/Website/ProductApp/Hero/Hero.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { useContext } from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { withPrefix } from 'gatsby';
 
 import Announcement from '~core/Announcement';
@@ -10,9 +10,9 @@ import Button from '~core/Button';
 import Heading from '~core/Heading';
 import Image from '~core/Image';
 import Paragraph from '~core/Paragraph';
+import Popover from '~core/Popover';
 import ThemeContext from '~layouts/WebsiteLayout/context';
 import SEO from '~parts/SEO';
-import { COLONY_APP } from '~routes';
 
 import styles from './Hero.module.css';
 
@@ -34,6 +34,11 @@ const MSG = defineMessages({
   buttonText: {
     id: 'pages.Website.ProductApp.Hero.buttonText',
     defaultMessage: 'Get Started',
+  },
+  tooltipColonyCreationDisabled: {
+    id: 'users.CreateColonyWizard.StepColonyName.tooltipColonyCreationDisabled',
+    // eslint-disable-next-line max-len
+    defaultMessage: `Due to the extraordinarily high Ethereum gas prices, we’ve decided to disable colony creation to prevent new users from incurring unexpectedly high costs. A new and improved Colony V2 will be available on xDai soon!`,
   },
 });
 
@@ -64,16 +69,46 @@ const Hero = () => {
             />
             <div className={styles.body}>
               <Paragraph appearance={{ size: 'medium' }} text={MSG.body} />
-              <Button
-                appearance={{
-                  borderRadius: 'none',
-                  size: 'large',
-                  theme: 'primary',
-                }}
-                className={styles.button}
-                linkTo={COLONY_APP}
-                text={MSG.buttonText}
-              />
+              <span className={styles.docsDropdownParent}>
+                <Popover
+                  appearance={{ theme: 'dark' }}
+                  content={() => (
+                    <div className={styles.colonyCreationDisabled}>
+                      <FormattedMessage
+                        {...MSG.tooltipColonyCreationDisabled}
+                      />
+                    </div>
+                  )}
+                  /*
+                   * `isOpen` is always true for a11y purposes. This ensures the dropdown
+                   * menu is always in the DOM, and visibility is controlled via CSS.
+                   */
+                  isOpen
+                  placement="top"
+                  popperProps={{
+                    modifiers: {
+                      offset: {
+                        offset: '0, 15px',
+                      },
+                    },
+                  }}
+                  trigger="disabled"
+                  wrapperClassName={styles.docsDropdownContainer}
+                >
+                  <span>
+                    <Button
+                      appearance={{
+                        borderRadius: 'none',
+                        size: 'large',
+                        theme: 'primary',
+                      }}
+                      className={styles.button}
+                      text={MSG.buttonText}
+                      disabled
+                    />
+                  </span>
+                </Popover>
+              </span>
             </div>
           </div>
         </div>

--- a/src/modules/pages/components/Website/ProductApp/Hero/Hero.module.css
+++ b/src/modules/pages/components/Website/ProductApp/Hero/Hero.module.css
@@ -95,6 +95,23 @@
   color: #ffffff;
 }
 
+.main .button:disabled:hover,
+.main .button:disabled:active {
+  background-color: #788CA0;
+  border-color: #ffffff;
+  color: #ffffff;
+}
+
+.docsDropdownParent .docsDropdownContainer {
+  display: none;
+  visibility: hidden;
+}
+
+.colonyCreationDisabled {
+  width: 420px;
+  padding: 15px;
+}
+
 @media (mediumUp) {
   .row {
     flex-direction: row;
@@ -111,5 +128,14 @@
   .body {
     margin-top: 50px;
     padding-right: 50px;
+  }
+
+  .docsDropdownParent .docsDropdownContainer {
+    display: block;
+  }
+
+  .docsDropdownParent:hover .docsDropdownContainer,
+  .docsDropdownParent:focus-within .docsDropdownContainer {
+    visibility: visible;
   }
 }


### PR DESCRIPTION
## Description

This PR disables the "Get Started" links to the app, as well as removing direct links to the `Betacolony`.

This is due to the fact that the current gas fees for Ethereum transactions are through the roof.

**Changes**

- [x] Remove link to `Betacolony` from the `Header`
- [x] Disable "Get Started" button on hero home page
- [x] Disable "Get Started" button on hero app page
- [x] Remove link to `Betacolony` on metacolony hero page
- [x] Remove link to `Betacolony` on metacolony team page

**Screenshots**

![Screenshot from 2020-09-03 19-05-47](https://user-images.githubusercontent.com/1193222/92141739-88827480-ee1b-11ea-82da-369946e3f5de.png)

![Screenshot from 2020-09-03 19-23-31](https://user-images.githubusercontent.com/1193222/92141746-89b3a180-ee1b-11ea-88b0-509144f12ae3.png)

