### PR TITLE
Authenticate with DockerHub on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
   build:
     docker:
       - image: circleci/node:10.12
+        auth:
+          username: colonyci
+          password: $COLONYCI_DOCKERHUB_PASSWORD
     working_directory: ~/repo
     steps:
       - checkout
@@ -27,6 +30,9 @@ jobs:
   deploy:
     docker:
       - image: circleci/node:10.1
+        auth:
+          username: colonyci
+          password: $COLONYCI_DOCKERHUB_PASSWORD
     working_directory: ~/repo
     steps:
       - checkout
@@ -51,8 +57,10 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - build
+      - build:
+          context: dockerhub-credentials
       - deploy:
+          context: dockerhub-credentials
           requires:
             - build
           filters:


### PR DESCRIPTION
[See the discussion here](https://discuss.circleci.com/t/updated-authenticate-with-docker-to-avoid-impact-of-nov-1st-rate-limits/37567/46).

You can tell this is (hopefully) correct by comparing the output under 'Spin up environment' from a [previous build](https://app.circleci.com/pipelines/github/JoinColony/JoinColony.github.io/41/workflows/72c38a90-5710-4012-8dad-63d38cf85036/jobs/1079) to this one. The former warns about no authentication, and [the build from this PR](https://app.circleci.com/pipelines/github/JoinColony/JoinColony.github.io/43/workflows/b6a12bbc-4bd9-44e6-aa62-873d7a86c77d/jobs/1081) does not.