### PR TITLE
Change discord link to point to #general

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -29,7 +29,7 @@ export const PAGE_TERMS_SERVICE = '/terms';
  * Absolute
  */
 export const COLONY_BLOG = 'https://blog.colony.io';
-export const COLONY_DISCORD = 'https://discord.gg/PDEQvrC';
+export const COLONY_DISCORD = 'https://discord.gg/Qjupxvg';
 export const COLONY_DISCOURSE = 'https://build.colony.io';
 export const COLONY_DISCOURSE_PROJECTS = `${COLONY_DISCOURSE}/c/projects`;
 export const COLONY_DISCOURSE_SUPPORT = `${COLONY_DISCOURSE}/c/support`;


### PR DESCRIPTION
The old discord link pointed to the `#dev-contracts` channel, this one should send the people to `#general` instead (although I don't really know how that works - I'm always getting into the welcome screen first).
